### PR TITLE
Set nox default sessions and remove LaTeX equations

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -83,13 +83,15 @@ Ready to contribute? Here's how to set up *brie* for local development.
 
 6. When you're done making changes, you can now run *nox* to check that the tests
    pass and that there isn't any lint::
-   pass and check that your changes pass flake8 and the
-   tests::
 
     $ nox -s test  # run test unit tests
     $ nox -s test-notebooks  # test that the notebooks successfully
     $ nox -s test-bmi  # test the bmi
     $ nox -s lint  # find and, where possible, remove lint (black, flake8, etc.)
+
+  To run all of the above in a single command::
+
+    $ nox
 
 7. Commit your changes and push your branch to GitHub::
 
@@ -99,7 +101,7 @@ Ready to contribute? Here's how to set up *brie* for local development.
 
 8. Submit a pull request through the GitHub website.
 
-.. _nox:: https://nox.thea.codes/
+.. _nox: https://nox.thea.codes/
 
 Pull Request Guidelines
 -----------------------

--- a/brie/alongshore_transporter.py
+++ b/brie/alongshore_transporter.py
@@ -39,7 +39,7 @@ def calc_alongshore_transport_k(
     rho_water=1050.0,
     gamma_b=0.78,
 ):
-    r"""Calculate alongshore transport diffusion coefficient.
+    """Calculate alongshore transport diffusion coefficient.
 
     The diffusion coefficient is calculated from Nienhuis, Ashton, Giosan, 2015 [1]_ .
     Note that the Ashton, 2006 value for *k* is incorrect.
@@ -64,18 +64,18 @@ def calc_alongshore_transport_k(
     Notes
     -----
 
-    The sediment transport constant, :math:`K_1`, is calculated as follows,
+    The sediment transport constant, ``K_1``, is calculated as follows::
 
-    .. math::
+        K_1 = (
+            5.3e-6
+            * K
+            * (1 / (2 * n)) ** (6 / 5)
+            * (sqrt(g * gamma_b) / (2 * pi)) ** (1 / 5)
+        )
 
-        K_1 = 5.3 \cdot 10^{-6} K \left( \frac{1}{2n} \right)^{6 \over 5} \left( \frac{\sqrt{g \gamma_b}} {2 \pi} \right)^{1 \over 5}
+    where::
 
-    where:
-
-    .. math::
-
-        K = 0.46 \rho g^{3 \over 2}
-
+        K = 0.46 * rho_g ** (3 / 2)
     """
     return (
         5.3e-6
@@ -138,7 +138,7 @@ def calc_shoreline_angles(y, spacing=1.0, out=None):
 
 
 def calc_coast_qs(wave_angle, wave_height=1.0, wave_period=10.0):
-    r"""Calculate coastal alongshore sediment transport for a given incoming wave angle.
+    """Calculate coastal alongshore sediment transport for a given incoming wave angle.
 
     Parameters
     ----------
@@ -163,14 +163,18 @@ def calc_coast_qs(wave_angle, wave_height=1.0, wave_period=10.0):
     Alongshore sediment transport is computed using the CERC or Komar
     (Komar, 1998 [2]_ ) formula, reformulated into deep-water wave properties
     (Ashton and Murray, 2006 [3]_ ) by back-refracting the waves over shore-parallel
-    contours, which yields:
+    contours, which yields::
 
-    .. math::
+        Q_s = (
+            K_1
+            * H_w ** (12 / 5)
+            * T ** (1 / 5)
+            * cos(d_theta) ** (6 / 5)
+            * sin(d_theta)
+        )
 
-        Q_s = K_1 \cdot H_s^{12/5} T^{1/5} \cos^{6/5}\left( \Delta \theta \right) \sin \left(\Delta \theta\right)
-
-    where :math:`H_s` is the offshore deep-water significant wave height (in meters),
-    :math:`T` is the wave period (in seconds), and :math:`\Delta \theta` is the
+    where ``H_s`` is the offshore deep-water significant wave height (in meters),
+    ``T`` is the wave period (in seconds), and ``d_theta`` is the
     deep-water wave approach angle relative to the local shoreline orientation (rads).
 
     References
@@ -236,14 +240,20 @@ def calc_coast_diffusivity(
     berm_ele=2.0,
     n_bins=181,
 ):
-    r"""Calculate sediment diffusion along a coastline. Corresponds to Equations 37-39 in NLT19 [1]_, with formulations from
-    AM06 [2]_.
+    """Calculate sediment diffusion along a coastline.
 
-    .. math::
+    Corresponds to Equations 37-39 in NLT19 [1]_, with formulations from AM06 [2]_::
 
-        D \left( \theta \right) = k/(H_b+D_T) \cdot H_0 ^{12/5} T^{1/5} \cdot [E \left( \phi_0 \right) * \psi \left( \phi_0 - \theta \right)]
+        D(theta) = (
+            k
+            / (H_b + D_T)
+            * H_0 ** (12 / 5)
+            * T ** (1 / 5)
+            * (E(phi_0) * psi(phi_0 - theta))
+        )
 
-    where :math:`E\left( \phi_0 \right)` is the normalized angular distribution of wave energy, and :math:`\psi \left( \phi_0 - \theta \right)` is the angle depdendence of diffusivity.
+    where ``E(phi_0)`` is the normalized angular distribution of wave energy, and
+    ``psi(phi_0 - theta)`` is the angle depdendence of diffusivity.
 
 
     References

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,6 +8,9 @@ PROJECT = "brie"
 ROOT = pathlib.Path(__file__).parent
 
 
+nox.options.sessions = ["lint", "test", "test-bmi", "test-notebooks"]
+
+
 @nox.session
 def test(session: nox.Session) -> None:
     """Run the tests."""


### PR DESCRIPTION
This is a small pull request that sets the default *nox* sessions to be *lint*, *test*, *test-bmi*, and *test-notebooks*. This means that to run all of those sessions, you can just run,
```bash
$ nox
```
You can, of course, still run the individual sessions as before with the `-s` option (e.g. `nox -s lint`). I've updated the contributing doc to describe this.

I've also converted the LaTeX equations in the docstrings to regular text equations to make them easier to read.